### PR TITLE
wake receiver on send drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ async = ["futures"]
 futures = { version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["macros", "rt"] }
+tokio = { version = "1.0", features = ["macros", "rt", "time"] }


### PR DESCRIPTION
When the sender is dropped, we need to wake up any waiting receive tasks.